### PR TITLE
Create GitHub Action for docker build and push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Docker build and publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v3
+
+    - name: Login to Quay.io
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: quay.io/${{ env.QUAY_REPOSITORY }}/ansible-devspace:


### PR DESCRIPTION
Create a GitHub action in the file "docker-publish.yml" to build the container, login using username/password secrets kept under GitHub secrets, and push to a repository defined in the GitHub environment variables.